### PR TITLE
Improve warnings for TomTom

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -201,6 +201,12 @@ extract_errors_from_results <- function(method, response, verbose) {
       if ("error_description" %in% names(raw_results)) message(paste0('Error: ', raw_results$error_description))
       else if ("title" %in% names(raw_results)) message(paste0('Error: ', raw_results$title))
     } 
+    else if ((method == 'tomtom') & (!is.data.frame(raw_results$addresses)) & (!is.data.frame(raw_results$results))){
+      if ('errorText' %in% names(raw_results)) {
+        message(paste0('Error: ', raw_results$errorText))
+      }
+    }
+    
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -205,6 +205,9 @@ extract_errors_from_results <- function(method, response, verbose) {
       if ('errorText' %in% names(raw_results)) {
         message(paste0('Error: ', raw_results$errorText))
       }
+      else if ('error' %in% names(raw_results)) {
+        message(paste0('Error: ', raw_results$error))
+      }
     }
     
   }

--- a/sandbox/query_debugging/tomtom_test.R
+++ b/sandbox/query_debugging/tomtom_test.R
@@ -46,16 +46,17 @@ full_results_flat <-
 full_results_flat
 
 # Error on bad user
-response <-
-  httr::GET(
-    url = gsub(" ", "%20", paste0(url_base, addr, ".json")),
-    query = list(
+
+response <- tidygeocoder:::query_api(
+  api_url = gsub(" ", "%20", paste0(url_base, addr, ".json")),
+    query_parameters =  list(
       limit = 1,
-      #key = tidygeocoder:::get_key(selected_method),
-      key = "aa",
+      key = tidygeocoder:::get_key(selected_method),
       language = "FFFFF"
     )
   )
+raw_results <- jsonlite::fromJSON(response$content)
+
 httr::status_code(response)
 httr::warn_for_status(response)
 httr::content(response, as = 'text', encoding = "UTF-8")

--- a/sandbox/reverse_queries/tomtom_reverse.R
+++ b/sandbox/reverse_queries/tomtom_reverse.R
@@ -44,21 +44,51 @@ full_results_flat <-
     flatten = TRUE
   )
 
+# Error
+
+errorres <- tidygeocoder::query_api(
+  gsub(" ", "%20", paste0(url_base, lat, ",", lon, ".json")),
+       query = list(
+         limit = 1,
+         key = tidygeocoder:::get_key("tomtom")
+       )
+)
+
+jsonlite::fromJSON(errorres$content)
+
 # Test reverse_geo ----
 library(tibble)
 
 lat <- 40.4055517
 lon <- -3.6802152
 # Error
+tidygeocoder::geo("Nieva",
+                  method = "tomtom",
+                  custom_query = list(language = "xxx"))
+
+tidygeocoder::geo("Nieva",
+                  method = "tomtom",
+                  custom_query = list(key = "xxx"))
+
 tidygeocoder::reverse_geo(
   lat = lat,
   long = lon,
-  verbose = TRUE,
   method = "tomtom",
   custom_query = list(
-    language = "papa"
+    key = "xxx"
   )
 )
+
+tidygeocoder::reverse_geo(
+  lat = lat,
+  long = lon,
+  method = "tomtom",
+  custom_query = list(
+    language = "xxx"
+  )
+)
+
+# End errors
 
 tidygeocoder::reverse_geo(
   lat = lat,


### PR DESCRIPTION
Hi, I have been testing the new warning functions. In the case of TomTom, the warning when the key is not valid is an HTML, but there are another warnings that are passed on the JSON response. I have created a quick reprex so you can check how messages are displayed under this branch:

``` r
# Error
tidygeocoder::geo("Nieva",
                  method = "tomtom",
                  custom_query = list(language = "xxx"))
#> Warning in query_api(api_url, api_query_parameters): Bad Request (HTTP 400).
#> Error: Error parsing 'language': Language tag 'xxx' not supported
#> # A tibble: 1 x 3
#>   address   lat  long
#>   <chr>   <dbl> <dbl>
#> 1 Nieva      NA    NA

tidygeocoder::geo("Nieva",
                  method = "tomtom",
                  custom_query = list(key = "xxx"))
#> Warning in get_api_query(method, generic_query, custom_query): Custom API
#> Parameter 'key' was already specified
#> Warning in query_api(api_url, api_query_parameters): Forbidden (HTTP 403).
#> Error: <h1>Developer Inactive</h1>
#> # A tibble: 1 x 3
#>   address   lat  long
#>   <chr>   <dbl> <dbl>
#> 1 Nieva      NA    NA

tidygeocoder::reverse_geo(
  lat = 0,
  long = 0,
  method = "tomtom",
  custom_query = list(
    key = "xxx"
  )
)
#> Warning in get_api_query(method, generic_query, custom_query): Custom API
#> Parameter 'key' was already specified
#> Warning in query_api(api_url, api_query_parameters): Forbidden (HTTP 403).
#> Error: <h1>Developer Inactive</h1>
#> # A tibble: 1 x 3
#>     lat  long address
#>   <dbl> <dbl> <chr>  
#> 1     0     0 <NA>

tidygeocoder::reverse_geo(
  lat = 0,
  long = 0,
  method = "tomtom",
  custom_query = list(
    language = "xxx"
  )
)
#> Warning in query_api(api_url, api_query_parameters): Bad Request (HTTP 400).
#> Error: Invalid request: invalid language parameter: [xxx]
#> # A tibble: 1 x 3
#>     lat  long address
#>   <dbl> <dbl> <chr>  
#> 1     0     0 <NA>
```

<sup>Created on 2021-03-14 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>
