### PR TITLE
Improve Bing geo when no results are found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tidygeocoder (development version)
+
+- Fix a bug on Bing forward geocoding `geo()` when no results are found ([#112](https://github.com/jessecambon/tidygeocoder/issues/112)). Now an empty 
+result (instead an error) is thrown.
+
 # tidygeocoder 1.0.3
 
 ### New Features

--- a/R/query_factory.R
+++ b/R/query_factory.R
@@ -208,6 +208,22 @@ query_api <- function(api_url, query_parameters, mode = 'single',
     return(list(content = content, status = status_code))
   }
   
+  # Bing exception Issue #112
+  
+  if (mode == 'single' && method == "bing" && httr::status_code(response) == 200) {
+    raw_results <- jsonlite::fromJSON(content)
+    status_code <- 200
+
+    n_results <- raw_results$resourceSets$estimatedTotal
+
+    if (n_results == 0) {
+      status_code <- 404
+    }
+
+    httr::warn_for_status(status_code)
+    return(list(content = content, status = status_code))
+  }
+
   return(list(
       content = content, 
       status = httr::status_code(response)

--- a/sandbox/query_debugging/bing_test.R
+++ b/sandbox/query_debugging/bing_test.R
@@ -94,7 +94,7 @@ tidygeocoder::geo(
 
 # NUll result
 tidygeocoder::geo(
-  address = "xxxxxxxxxxxxxxxxxxxx",
+  address = "asdfghjkl",
   verbose = TRUE,
   lat = "latitude",
   long = "longitude",


### PR DESCRIPTION
Fix #112 

When using Bing on forward geocoding and no results are found, an 404 error code is thrown.

Sandbox modified to reflect that, checks passed.

@jessecambon suggestion, bump version to make clear this fix is in dev?