### PR TITLE
fix as_tibble() in extract_reverse_results(full_results = true)

### DIFF
--- a/R/results_processing.R
+++ b/R/results_processing.R
@@ -109,7 +109,7 @@ extract_results <- function(method, response, full_results = TRUE, flatten = TRU
 #' Extract reverse geocoding results 
 #' 
 #' @description
-#' Parses the output of the [query_api] function for reverse geoocding.
+#' Parses the output of the [query_api] function for reverse geoocoding.
 #' The address is extracted into the first column
 #' of the returned dataframe. This function is not used for batch 
 #' geocoded results. Refer to [query_api] for example

--- a/R/results_processing.R
+++ b/R/results_processing.R
@@ -167,7 +167,7 @@ extract_reverse_results <- function(method, response, full_results = TRUE, flatt
   
   # extract other results (besides single line address)
   if (full_results == TRUE) {
-    tibble::as_tibble(results <- switch(method,
+    results <- tibble::as_tibble(switch(method,
         'osm' = extract_osm_reverse_full(response),
         'iq' =  extract_osm_reverse_full(response),
         'geocodio' = response$results[!names(response$results) %in% c('formatted_address')],

--- a/man/extract_reverse_results.Rd
+++ b/man/extract_reverse_results.Rd
@@ -29,7 +29,7 @@ method(s). Limits number of results per coordinate.}
 geocoder results in tibble format
 }
 \description{
-Parses the output of the \link{query_api} function for reverse geoocding.
+Parses the output of the \link{query_api} function for reverse geoocoding.
 The address is extracted into the first column
 of the returned dataframe. This function is not used for batch
 geocoded results. Refer to \link{query_api} for example


### PR DESCRIPTION
There was a small glitch in the assignment. 

I wonder whether it would suffice to convert to tibble only once at the end of the function (also in `extract_results()`) and just work with data.frames before? Probably with minuscule effect on run time and function complexity, though, so probably not worth it.