### PR TITLE
dev notes: change order of steps to add new service

### DIFF
--- a/vignettes/developer_notes.Rmd
+++ b/vignettes/developer_notes.Rmd
@@ -73,15 +73,15 @@ This section documents how to add support for a new geocoder service to the pack
    * Add a row to `api_key_reference` if the service requires an API key.
    * If the service you are adding has batch geocoding capabilities, add the maximum batch size (as a row) to `batch_limit_reference`.
    * Add a row to `api_info_reference` with links to the service's website, documentation, and usage policy.
+* **[R/geo.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/geo.R)**
+    * If the service supports batch geocoding then add a new function in **[R/batch_geocoding.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/batch_geocoding.R)** and add it to the `batch_func_map` named list.
+* **[R/reverse_geo.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/reverse_geo.R)**
+    * Update the `get_coord_parameters()` function based on how the service passed latitude and longitude coordinates for reverse geocoding.
+    * If the service supports reverse batch geocoding then add a new function in **[R/reverse_batch_geocoding.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/reverse_batch_geocoding.R)** and add it to the `reverse_batch_func_map` named list.
 * **[R/results_processing.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/results_processing.R)**
     * Update the `extract_results()` function which is used for parsing single addresses (ie. not batch geocoding). You can see examples of how I've tested out parsing the results of geocoder services [here](https://github.com/jessecambon/tidygeocoder/tree/main/sandbox/query_debugging).
     * In a similar fashion, update the `extract_reverse_results()` function for reverse geocoding.
     * Update the `extract_errors_from_results()` function to extract error messages for invalid queries.
-* **[R/geo.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/geo.R)**
-    * If the service supports reverse batch geocoding then add a new function in **[R/batch_geocoding.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/batch_geocoding.R)** and add it to the `batch_func_map` named list.
-* **[R/reverse_geo.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/reverse_geo.R)**
-    * Update the `get_coord_parameters()` function based on how the service passed latitude and longitude coordinates for reverse geocoding.
-    * If the service supports reverse batch geocoding then add a new function in **[R/reverse_batch_geocoding.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/reverse_batch_geocoding.R)** and add it to the `reverse_batch_func_map` named list.
 * **[R/geo_methods.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/geo_methods.R)**
     * Add a new `geo_<method>()` convenience function to [R/geo_methods.R](https://github.com/jessecambon/tidygeocoder/blob/main/R/geo_methods.R). Note that these functions are deprecated and will be phased out in the future.
 * If applicable, add new tests to the scripts in the [tests directory](https://github.com/jessecambon/tidygeocoder/tree/main/tests/testthat) for the method. Note that tests should avoid making a HTTP query (ie. use `no_query = TRUE` in the `geo()` and `geocode()` functions.


### PR DESCRIPTION
This changes order of steps to add new service in the developer notes. (The new `reverse_geo()` method needs to be available before you can `debug extract_reverse_results()`)